### PR TITLE
Add the possibility of setting up the input id

### DIFF
--- a/examples/bootstrap/Bootstrap.elm
+++ b/examples/bootstrap/Bootstrap.elm
@@ -29,6 +29,7 @@ init =
                     | isDisabled = isDisabled
                     , inputClassList = [ ( "form-control", True ) ]
                     , inputName = Just "date"
+                    , inputId = Just "date-field"
                 }
     in
         { date = Nothing

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -49,6 +49,7 @@ type alias Settings =
     , classNamespace : String
     , inputClassList : List ( String, Bool )
     , inputName : Maybe String
+    , inputId : Maybe String
     , isDisabled : Date -> Bool
     , parser : String -> Result String Date
     , dateFormatter : Date -> String
@@ -101,6 +102,7 @@ defaultSettings =
     , classNamespace = "elm-datepicker--"
     , inputClassList = []
     , inputName = Nothing
+    , inputId = Nothing
     , isDisabled = always False
     , parser = Date.fromString
     , dateFormatter = formatDate
@@ -232,6 +234,11 @@ view (DatePicker ({ open, pickedDate, settings } as model)) =
         class =
             mkClass settings
 
+        potentialInputId =
+            settings.inputId
+                |> Maybe.map Attrs.id
+                |> (List.singleton >> List.filterMap identity)
+
         inputClasses =
             [ ( settings.classNamespace ++ "input", True ) ]
                 ++ settings.inputClassList
@@ -246,6 +253,7 @@ view (DatePicker ({ open, pickedDate, settings } as model)) =
                  , onClick Focus
                  , onFocus Focus
                  ]
+                    ++ potentialInputId
                     ++ xs
                 )
                 []


### PR DESCRIPTION
It can be useful to set up the id html attribute of the date input element.

That allows browser based automated testing tools to select the element or to use something like the Dom module.

This PR enables that by exposing an inputId field on the settings. The field is of type Maybe String, with the default value of Nothing. The input element is only setup if a value is present, since it's recommend to have unique html ids.