### PR TITLE
Text-Input State

### DIFF
--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -224,7 +224,6 @@ deriveDateFromText ({ currentMonth, forceOpen, inputText, pickedDate, settings }
                 |> Result.toMaybe
 
         newDate =
-            -- WTB Maybe.mapNothing! I.e. flattened withDefault
             case parsed of
                 Nothing ->
                     pickedDate

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -152,7 +152,10 @@ init settings =
                 , today = initDate
                 , currentMonth = initDate
                 , currentDates = []
-                , inputText = ""
+                , inputText =
+                    settings.pickedDate
+                        |> Maybe.map settings.dateFormatter
+                        |> Maybe.withDefault ""
                 , pickedDate = settings.pickedDate
                 , settings = settings
                 }

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -263,7 +263,15 @@ update msg (DatePicker ({ forceOpen, currentMonth, pickedDate, settings } as mod
                 month =
                     newPickedDate ?> currentMonth
             in
-                ( DatePicker <| prepareDates month { model | pickedDate = newPickedDate }
+                ( DatePicker <|
+                    prepareDates month
+                        { model
+                            | pickedDate = newPickedDate
+                            , inputText =
+                                newPickedDate
+                                    |> Maybe.map settings.dateFormatter
+                                    |> Maybe.withDefault ""
+                        }
                 , Cmd.none
                 , if valid then
                     newPickedDate

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -191,7 +191,11 @@ Set a new date in the datepicker
 -}
 setDate : Date -> DatePicker -> DatePicker
 setDate date (DatePicker model) =
-    DatePicker { model | pickedDate = Just date }
+    DatePicker
+        { model
+            | pickedDate = Just date
+            , inputText = model.settings.dateFormatter date
+        }
 
 
 {-|


### PR DESCRIPTION
A sketch for managing the state of the text input, to avoid blowing away user input during a re-render. From  #24. The objective is to make the picker retain an idea of its text input's state, and not overwrite whatever the user happens to be typing in the case of a DOM reflow, time-based model change, or any other incidental event.

The changes, in natural language so we know they're comprehensible. I suspect that there might be an _even more_ parsimonious minimal way to express absolutely correct state at all times, but I don't see any holes in this one...yet.

- add new state vars `editing` and `textInput`
- `editing` toggles as the text input gains and loses focus.
- `inputText` is probably best expressed as a merge of the following changes:
  - picking a date with the picker sets it to the formatted date
  - entering or leaving `editing` sets if to the formatted picked date, if any
  - typing in the field updates it with the raw typed value
- if `editing`, render the text input with the raw text input value. otherwise, render it with the formatted date. this is redundant with the second source of changes above, since presumably outside of `editing`, the input text _is_ the formatted date anyway, but I'm not infallible!