### PR TITLE
Make picker background opaque

### DIFF
--- a/css/elm-datepicker.scss
+++ b/css/elm-datepicker.scss
@@ -19,6 +19,7 @@ $datepicker-row-border-color: #F2F2F2;
   position: absolute;
   border: 1px solid $datepicker-border-color;
   z-index: 10;
+  background-color: white;
 }
 
 .#{$datepicker-ns}picker-header,


### PR DESCRIPTION
The picker background is currently transparent, which can make it hard to see the numbers, especially if there is text behind it. 
The change makes the background white.
![screenshot_2017-03-22_12-36-05](https://cloud.githubusercontent.com/assets/11493705/24198191/ca7714ba-0efc-11e7-8c77-a82aed4dc027.png)
