### PR TITLE
Expose the value of "today" in settings

### DIFF
--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -72,6 +72,7 @@ type alias Settings =
     , firstDayOfWeek : Day
     , pickedDate : Maybe Date
     , changeYear : YearRange
+    , today : Date
     }
 
 
@@ -128,6 +129,7 @@ defaultSettings =
     , firstDayOfWeek = Sun
     , pickedDate = Nothing
     , changeYear = off
+    , today = initDate
     }
 
 
@@ -215,14 +217,14 @@ init : Settings -> ( DatePicker, Cmd Msg )
 init settings =
     let
         date =
-            settings.pickedDate ?> initDate
+            settings.pickedDate ?> settings.today
     in
         ( DatePicker <|
             prepareDates date
                 { open = False
                 , forceOpen = False
-                , today = initDate
-                , currentMonth = initDate
+                , today = date
+                , currentMonth = date
                 , currentDates = []
                 , inputText =
                     settings.pickedDate


### PR DESCRIPTION
Fixes #36 

When the initial date is Nothing, clicking on the DatePicker brings up a pop-up box with the date set to 29/05/1992. However we want this date to be "today", or any other date we choose.

This exposes the concept of `today` in the settings enabling the default date to be overridden. If `today` is not set, then `initDate` is still used, so the current behaviour does not change.
