### PR TITLE
Nonlocal date

### DIFF
--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -267,6 +267,7 @@ update settings msg (DatePicker ({ forceOpen, focused } as model)) =
                 { model
                     | open = False
                     , inputText = Nothing
+                    , focused = Nothing
                 }
             , Cmd.none
             , Changed date

--- a/src/DatePicker/Date.elm
+++ b/src/DatePicker/Date.elm
@@ -567,8 +567,8 @@ newYear currentMonth newYear =
             Debug.crash ("Unknown Month " ++ (toString currentMonth))
 
 
-yearRange : { today : Date, currentMonth : Date } -> YearRange -> List Int
-yearRange { today, currentMonth } range =
+yearRange : { focused : Date, currentMonth : Date } -> YearRange -> List Int
+yearRange { focused, currentMonth } range =
     case range of
         MoreOrLess num ->
             List.range ((year currentMonth) - num) ((year currentMonth) + num)
@@ -577,10 +577,10 @@ yearRange { today, currentMonth } range =
             List.range start end
 
         From year_ ->
-            List.range year_ (year today)
+            List.range year_ (year focused)
 
         To year_ ->
-            List.range (year today) year_
+            List.range (year focused) year_
 
         Off ->
             []


### PR DESCRIPTION
From the fruitful discussion in #35, this removes any notion of the currently chosen date from datepicker state, delegating that state to the user in the manner of [sortable-table](https://github.com/evancz/elm-sortable-table). It also removes settings from the model, in the spirit of the strongly stated [usage rules](https://github.com/evancz/elm-sortable-table#usage-rules).

`One of the core rules of The Elm Architecture is never put functions in your Model or Msg types`

Major effects:

* `settings` is now an argument to `update` and `view`
* A `pickedDate : Maybe Date` is an argument to `view`
* `update` returns `DateEvent` to indicate when the component thinks the user would like a new date
* `focused` (formerly the somewhat confusingly named `today`) and `inputText` are now `Maybe`. Both are cleared when the picker tries to change the date. The rendered state of the picker is derived from these or just from the `pickedDate`.
* The incrementing messages like `NextMonth` are now just `ChangeFocus`, since you may want to change the displayed dates in the picker to "a month from the picked date", which isn't part of `update`.
* `prepareDates` is now called in `view`. I'm conscious of performance, but I feel like JS is probably fast enough to cope with this?

I've tested a bit locally and it seems to at least pass the laugh test. 1 million points to Elm for making this kind of refactor a little less scary.
