### PR TITLE
add a required attribute to the settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /elm-stuff
 /elm.js
+/.idea

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -67,6 +67,7 @@ type alias Settings =
     , cellFormatter : String -> Html Msg
     , firstDayOfWeek : Day
     , changeYear : YearRange
+    , required : Bool
     }
 
 
@@ -125,6 +126,7 @@ defaultSettings =
     , cellFormatter = formatCell
     , firstDayOfWeek = Sun
     , changeYear = off
+    , required = False
     }
 
 
@@ -364,6 +366,7 @@ view pickedDate settings (DatePicker ({ open } as model)) =
                  , onBlur Blur
                  , onClick Focus
                  , onFocus Focus
+                 , Attrs.required settings.required
                  ]
                     ++ potentialInputId
                     ++ xs


### PR DESCRIPTION
This allows the date picker to participate in normal form validation automatically and should not have any impact if the user doesn't want to use it