### PR TITLE
Prevent default action when clicking on a day

### DIFF
--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -448,9 +448,16 @@ datePicker pickedDate settings ({ focused, today } as model) =
                 disabled =
                     settings.isDisabled d
 
+                onDayClick =
+                    Json.succeed >>
+                        onWithOptions
+                            "click"
+                            { stopPropagation = True
+                            , preventDefault = True }
+
                 props =
                     if not disabled then
-                        [ onClick (Pick (Just d)) ]
+                        [ onDayClick (Pick (Just d)) ]
                     else
                         []
             in


### PR DESCRIPTION
This avoids a problem when the date picker is located inside an
HTML <label> element. The default action of clicking on a
(block-level) label is to focus an input inside the label
(either the one explicitly indicated by the label's "for"
attribute or the first one). The result is that the date picker
is blurred and then immediately refocused -- and therefore
stays open.