### PR TITLE
Expose the currently focused date

### DIFF
--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -15,13 +15,14 @@ module DatePicker
         , off
         , from
         , to
+        , focusedDate
         )
 
 {-| A customizable date picker component.
 
 # Tea ☕
 @docs Msg, DateEvent, DatePicker
-@docs init, update, view, isOpen
+@docs init, update, view, isOpen, focusedDate
 
 # Settings
 @docs Settings, defaultSettings, pick, between, moreOrLess, from, to, off
@@ -244,6 +245,13 @@ Expose if the datepicker is open
 isOpen : DatePicker -> Bool
 isOpen (DatePicker model) =
     model.open
+
+
+{-| Expose the currently focused date
+-}
+focusedDate : DatePicker -> Maybe Date
+focusedDate (DatePicker model) =
+    model.focused
 
 
 {-| A sugaring of `Maybe` to explicitly tell you how to interpret `Changed Nothing`, because `Just Nothing` seems somehow wrong.


### PR DESCRIPTION
Add `focusedDate : DatePicker -> Maybe Date` to expose the currently focused date.

The use case I have is that when the user clicks forward and back through months, I want to fetch data about the current month via an API call (so that I can know whether specific days should be disabled or not). So I can now use the currently focused date to know which API call to make.

This approach has been working well for me. I'd be interested to hear your thoughts on this change.

Thanks for the great library!