### PR TITLE
Sketch of controlled initialization

### DIFF
--- a/examples/controlled/.gitignore
+++ b/examples/controlled/.gitignore
@@ -1,0 +1,1 @@
+controlled.js

--- a/examples/controlled/Controlled.elm
+++ b/examples/controlled/Controlled.elm
@@ -1,0 +1,104 @@
+module Controlled exposing (main)
+
+import Date exposing (Date, Day(..), day, dayOfWeek, month, year)
+import DatePicker exposing (defaultSettings, DateEvent(..))
+import Html exposing (Html, div, h1, text)
+import Time
+
+
+type Msg
+    = ToDatePicker DatePicker.Msg
+
+
+type alias Model =
+    { date : Maybe Date
+    , datePicker : DatePicker.DatePicker
+    }
+
+
+settings : DatePicker.Settings
+settings =
+    let
+        isDisabled date =
+            dayOfWeek date
+                |> flip List.member [ Sat, Sun ]
+    in
+        { defaultSettings | isDisabled = isDisabled }
+
+
+init : ( Model, Cmd Msg )
+init =
+    let
+        ( datePicker, datePickerFx ) =
+            let
+                state =
+                    DatePicker.defaultState
+                        |> (\it ->
+                                { it
+                                    | focused =
+                                        Time.hour
+                                        |> Date.fromTime
+                                        |> Just
+                                    , today = Time.hour
+                                        |> Date.fromTime
+                                }
+                           )
+            in
+                DatePicker.initWithState state
+    in
+        { date = Nothing
+        , datePicker = datePicker
+        }
+            ! []
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg ({ date, datePicker } as model) =
+    case msg of
+        ToDatePicker msg ->
+            let
+                ( newDatePicker, datePickerFx, dateEvent ) =
+                    DatePicker.update settings msg datePicker
+
+                newDate =
+                    case dateEvent of
+                        Changed newDate ->
+                            newDate
+
+                        _ ->
+                            date
+            in
+                { model
+                    | date = newDate
+                    , datePicker = newDatePicker
+                }
+                    ! [ Cmd.map ToDatePicker datePickerFx ]
+
+
+view : Model -> Html Msg
+view ({ date, datePicker } as model) =
+    div []
+        [ case date of
+            Nothing ->
+                h1 [] [ text "Pick a date" ]
+
+            Just date ->
+                h1 [] [ text <| formatDate date ]
+        , DatePicker.view date settings datePicker
+            |> Html.map ToDatePicker
+        ]
+
+
+formatDate : Date -> String
+formatDate d =
+    toString (month d) ++ " " ++ toString (day d) ++ ", " ++ toString (year d)
+
+
+main : Program Never Model Msg
+main =
+    Html.program
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = always Sub.none
+        }

--- a/examples/controlled/index.html
+++ b/examples/controlled/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <title>elm-datepicker example</title>
+
+    <link rel="stylesheet"
+          type="text/css"
+          href="https://necolas.github.io/normalize.css/4.1.1/normalize.css" />
+
+    <link rel="stylesheet"
+          type="text/css"
+          href="https://fonts.googleapis.com/css?family=Roboto" />
+
+    <link rel="stylesheet"
+          type="text/css"
+          href="../../css/elm-datepicker.css" />
+
+    <style type="text/css">
+      body {
+          font-family: 'Roboto', sans-serif;
+      }
+
+      .container {
+          width: 680px;
+          margin: 0 auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div id="controlled">
+      </div>
+    </div>
+
+    <script src="controlled.js"></script>
+    <script>
+      Elm.Controlled.embed(document.getElementById("controlled"));
+    </script>
+  </body>
+</html>

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -254,8 +254,8 @@ init =
 
 
 {-| Initialize with raw state so you can control anything you like.
-    The returned command sets the picker to Date.now; you should execute it if
-    you haven't supplied `today` and `focused`.
+    The returned command sets the picker to Date.now, so you should execute it if
+    you want Date.now values for `focused` and `today`.
 -}
 initWithState : ControlledModel -> ( DatePicker, Cmd Msg )
 initWithState init =

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -5,7 +5,9 @@ module DatePicker
         , DateEvent(..)
         , DatePicker
         , defaultSettings
+        , defaultState
         , init
+        , initWithState
         , update
         , view
         , pick
@@ -22,10 +24,10 @@ module DatePicker
 
 # Tea ☕
 @docs Msg, DateEvent, DatePicker
-@docs init, update, view, isOpen, focusedDate
+@docs init, initWithState, update, view, isOpen, focusedDate
 
 # Settings
-@docs Settings, defaultSettings, pick, between, moreOrLess, from, to, off
+@docs Settings, defaultState, defaultSettings, pick, between, moreOrLess, from, to, off
 -}
 
 import Date exposing (Date, Day(..), Month, day, month, year)
@@ -202,27 +204,45 @@ formatCell day =
     text day
 
 
-{-| Initialize a DatePicker given a Settings record.  You must execute
+{-| Default internal state for use with `initWithState`
+-}
+defaultState : Model
+defaultState =
+    { open = False
+    , forceOpen = False
+    , focused = Just initDate
+    , inputText = Nothing
+    , today = initDate
+    }
+
+
+{-| Initialize a DatePicker.  You must execute
 the returned command for the date picker to behave correctly.
 
 
     init =
       let
          (datePicker, datePickerFx) =
-           DatePicker.init defaultSettings
+           DatePicker.init
       in
          { picker = datePicker } ! [ Cmd.map ToDatePicker datePickerfx ]
 
 -}
 init : ( DatePicker, Cmd Msg )
 init =
+    ( DatePicker defaultState
+    , Task.perform CurrentDate Date.now
+    )
+
+
+{-| Initialize with raw state so you can control anything you like.
+    The returned command sets the picker to Date.now; you should execute it if
+    you haven't supplied `today` and `focused`.
+-}
+initWithState : Model -> ( DatePicker, Cmd Msg )
+initWithState init =
     ( DatePicker <|
-        { open = False
-        , forceOpen = False
-        , focused = Just initDate
-        , inputText = Nothing
-        , today = initDate
-        }
+        init
     , Task.perform CurrentDate Date.now
     )
 

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -90,6 +90,24 @@ type alias Model =
     }
 
 
+{-| Abstraction to allow user to submit initial state _that they know about_
+    without coupling precisely to the inner state of the picker.
+-}
+type alias ControlledModel =
+    { open : Bool
+    , forceOpen : Bool
+    , focused :
+        Maybe Date
+        -- date currently center-focused by picker, but not necessarily chosen
+    , inputText :
+        Maybe String
+        -- for user input that hasn't yet been submitted
+    , today :
+        Date
+        -- actual, current day as far as we know
+    }
+
+
 {-| The DatePicker model. Opaque, hence no field docs.
 -}
 type DatePicker
@@ -239,7 +257,7 @@ init =
     The returned command sets the picker to Date.now; you should execute it if
     you haven't supplied `today` and `focused`.
 -}
-initWithState : Model -> ( DatePicker, Cmd Msg )
+initWithState : ControlledModel -> ( DatePicker, Cmd Msg )
 initWithState init =
     ( DatePicker <|
         init


### PR DESCRIPTION
From #43. Since the initial request was to give control over both `focused` and `today`, I figured "Why not just allow the initial model to be specified?"

* Create a `ControlledModel` that is currently a copy of the model
* Expose `initWithState` that just says "Hey man, you can set anything you want!"
* Expose `defaultState` to avoid a lot of homework when doing so

Open items/thoughts:
* The returned command is _slightly_ tricky since you need to execute IFF you haven't set `focused` or `today`. An alternate option would be to say "If you try to control initial state, it's completely on you" and return no command. Requires work from the user but it less potentially ambiguous.
* Can you think of any danger in exposing the other keys of `ControlledModel`? I was trying to extrapolate to other future needs to get ahead of any ensuing API changes (when, e.g. someone says "Hey, I'd like to start them with a given text entered" or whatnot).