### PR TITLE
use `defaultValue` rather than `value` for the <input> attribute

### DIFF
--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -452,12 +452,13 @@ view pickedDate settings (DatePicker ({ open } as model)) =
                     |> defaultValue
                 ]
     in
-        div [ class "container" ]
-            [ dateInput
+        Html.Keyed.node "div"
+            [ class "container" ]
+            [ ( "dateInput", dateInput )
             , if open then
-                datePicker pickedDate settings model
+                ( "datePicker", datePicker pickedDate settings model )
               else
-                text ""
+                ( "text", text "" )
             ]
 
 

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -38,7 +38,7 @@ module DatePicker
 import Date exposing (Date, Day(..), Month, day, month, year)
 import DatePicker.Date exposing (..)
 import Html exposing (..)
-import Html.Attributes as Attrs exposing (href, placeholder, tabindex, type_, value, selected)
+import Html.Attributes as Attrs exposing (href, placeholder, tabindex, type_, value, defaultValue, selected)
 import Html.Events exposing (on, onBlur, onClick, onInput, onFocus, onWithOptions, targetValue)
 import Html.Keyed
 import Json.Decode as Json
@@ -449,7 +449,7 @@ view pickedDate settings (DatePicker ({ open } as model)) =
                         (Maybe.map settings.dateFormatter pickedDate
                             |> Maybe.withDefault ""
                         )
-                    |> value
+                    |> defaultValue
                 ]
     in
         div [ class "container" ]


### PR DESCRIPTION
Due to https://github.com/elm-lang/virtual-dom/issues/107, the date text `<input>` element will drop characters if you type really fast. This is particularly problematic in automated tests (where text is entered extremely quickly). 

This uses the `defaultValue` with `Html.Keyed.node` workaround as suggested in https://github.com/elm-lang/html/issues/105#issuecomment-309524197.