### PR TITLE
Example on creating simple date range selection

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,10 @@
-all: simple-example bootstrap-example
+all: simple-example bootstrap-example range-example
 
 simple-example:
 	cd .. && elm make --warn examples/simple/Simple.elm --output=examples/simple/simple.js
 
 bootstrap-example:
 	cd .. && elm make --warn examples/bootstrap/Bootstrap.elm --output=examples/bootstrap/bootstrap.js
+
+range-example:
+	cd .. && elm make --warn examples/range/Range.elm --output=examples/range/range.js

--- a/examples/range/.gitignore
+++ b/examples/range/.gitignore
@@ -1,0 +1,1 @@
+range.js

--- a/examples/range/Range.elm
+++ b/examples/range/Range.elm
@@ -1,0 +1,184 @@
+module Range exposing (main)
+
+import Date exposing (Date, Day(..), day, dayOfWeek, month, year)
+import DatePicker exposing (defaultSettings, DateEvent(..))
+import Html exposing (Html, div, h1, text)
+
+
+type Msg
+    = ToStartDatePicker DatePicker.Msg
+    | ToEndDatePicker DatePicker.Msg
+
+
+type alias Model =
+    { startDate : Maybe Date
+    , endDate : Maybe Date
+    , startDatePicker : DatePicker.DatePicker
+    , endDatePicker : DatePicker.DatePicker
+    }
+
+
+
+-- Could be used to customize common settings for both date pickers. Like for
+-- example disabling weekends from them.
+
+
+commonSettings : DatePicker.Settings
+commonSettings =
+    defaultSettings
+
+
+
+-- Extend commonSettings with isDisabled function which would disable dates
+-- after already selected end date because range start should come before end.
+
+
+startSettings : Maybe Date -> DatePicker.Settings
+startSettings endDate =
+    let
+        isDisabled =
+            case endDate of
+                Nothing ->
+                    commonSettings.isDisabled
+
+                Just endDate ->
+                    \d ->
+                        Date.toTime d
+                            > Date.toTime endDate
+                            || (commonSettings.isDisabled d)
+    in
+        { commonSettings
+            | placeholder = "Pick a start date"
+            , isDisabled = isDisabled
+        }
+
+
+
+-- Extend commonSettings with isDisabled function which would disable dates
+-- before already selected start date because range end should come after start.
+
+
+endSettings : Maybe Date -> DatePicker.Settings
+endSettings startDate =
+    let
+        isDisabled =
+            case startDate of
+                Nothing ->
+                    commonSettings.isDisabled
+
+                Just startDate ->
+                    \d ->
+                        Date.toTime d
+                            < Date.toTime startDate
+                            || (commonSettings.isDisabled d)
+    in
+        { commonSettings
+            | placeholder = "Pick an end date"
+            , isDisabled = isDisabled
+        }
+
+
+init : ( Model, Cmd Msg )
+init =
+    let
+        ( startDatePicker, startDatePickerFx ) =
+            DatePicker.init
+
+        ( endDatePicker, endDatePickerFx ) =
+            DatePicker.init
+    in
+        { startDate = Nothing
+        , startDatePicker = startDatePicker
+        , endDate = Nothing
+        , endDatePicker = endDatePicker
+        }
+            ! ([ Cmd.map ToStartDatePicker startDatePickerFx ]
+                ++ [ Cmd.map
+                        ToEndDatePicker
+                        endDatePickerFx
+                   ]
+              )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        ToStartDatePicker msg ->
+            let
+                ( newDatePicker, datePickerFx, dateEvent ) =
+                    DatePicker.update (startSettings model.endDate) msg model.startDatePicker
+
+                newDate =
+                    case dateEvent of
+                        Changed newDate ->
+                            newDate
+
+                        _ ->
+                            model.startDate
+            in
+                { model
+                    | startDate = newDate
+                    , startDatePicker = newDatePicker
+                }
+                    ! [ Cmd.map ToStartDatePicker datePickerFx ]
+
+        ToEndDatePicker msg ->
+            let
+                ( newDatePicker, datePickerFx, dateEvent ) =
+                    DatePicker.update (endSettings model.startDate) msg model.endDatePicker
+
+                newDate =
+                    case dateEvent of
+                        Changed newDate ->
+                            newDate
+
+                        _ ->
+                            model.endDate
+            in
+                { model
+                    | endDate = newDate
+                    , endDatePicker = newDatePicker
+                }
+                    ! [ Cmd.map ToEndDatePicker datePickerFx ]
+
+
+view : Model -> Html Msg
+view model =
+    div []
+        [ viewRange model.startDate model.endDate
+        , DatePicker.view model.startDate (startSettings model.endDate) model.startDatePicker
+            |> Html.map ToStartDatePicker
+        , DatePicker.view model.endDate (endSettings model.startDate) model.endDatePicker
+            |> Html.map ToEndDatePicker
+        ]
+
+
+viewRange : Maybe Date -> Maybe Date -> Html Msg
+viewRange start end =
+    case ( start, end ) of
+        ( Nothing, Nothing ) ->
+            h1 [] [ text "Pick dates" ]
+
+        ( Just start, Nothing ) ->
+            h1 [] [ text <| formatDate start ++ " – Pick end date" ]
+
+        ( Nothing, Just end ) ->
+            h1 [] [ text <| "Pick start date – " ++ formatDate end ]
+
+        ( Just start, Just end ) ->
+            h1 [] [ text <| formatDate start ++ " – " ++ formatDate end ]
+
+
+formatDate : Date -> String
+formatDate d =
+    toString (month d) ++ " " ++ toString (day d) ++ ", " ++ toString (year d)
+
+
+main : Program Never Model Msg
+main =
+    Html.program
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = always Sub.none
+        }

--- a/examples/range/index.html
+++ b/examples/range/index.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <title>elm-datepicker example</title>
+
+    <link rel="stylesheet"
+          type="text/css"
+          href="https://necolas.github.io/normalize.css/4.1.1/normalize.css" />
+
+    <link rel="stylesheet"
+          type="text/css"
+          href="https://fonts.googleapis.com/css?family=Roboto" />
+
+    <link rel="stylesheet"
+          type="text/css"
+          href="../../css/elm-datepicker.css" />
+
+    <style type="text/css">
+      body {
+          font-family: 'Roboto', sans-serif;
+      }
+
+      .container {
+          width: 680px;
+          margin: 0 auto;
+      }
+
+      #range > div {
+        display: flex;
+        flex-wrap: wrap;
+      }
+
+      #range h1 {
+        min-width: 100%;
+      }
+
+      #range > div > div:last-child::before {
+        content: "–";
+        padding: 0 1em;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div id="range">
+      </div>
+    </div>
+
+    <script src="range.js"></script>
+    <script>
+      Elm.Range.embed(document.getElementById("range"));
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Implementation wraps two date pickers one for range start and other for range end. Value from other input is used to disable date selections which would create invalid ranges.

This kind of usage could provide naive workaround to #51 although issue reporter probably meant implementation similar to something shown in [this Dribbble design](https://dribbble.com/shots/3006595-Date-range-selector).

Could this PR be something which would bring additional value to examples and therefore be merged? I'm quite new to Elm so if you have ideas for improvement I'm happy to hear them too.