### PR TITLE
revert PR #58 and add some Nightwatch tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 /elm-stuff
 /elm.js
 /.idea
+/node_modules
+
+#nightwatch reports
+/reports

--- a/README.md
+++ b/README.md
@@ -112,3 +112,20 @@ from [here][scss].
 
 [compiled]: https://github.com/elm-community/elm-datepicker/blob/master/css/elm-datepicker.css
 [scss]: https://github.com/elm-community/elm-datepicker/blob/master/css/elm-datepicker.scss
+
+
+## Running the acceptance tests
+### Prerequisites
+
+- elm reactor - this is most likely already installed if you're using Elm!
+- chromedriver (https://sites.google.com/a/chromium.org/chromedriver/).
+  Try `brew install chromedriver` if you're on OSX.
+
+
+### Install the testing tools
+run `npm install`
+
+### Run the tests
+`./run-acceptance-tests`
+
+Please file an issue if you have any difficulty running the tests.

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-all: simple-example bootstrap-example range-example
+all: simple-example bootstrap-example range-example simple-nightwatch-example
 
 simple-example:
 	cd .. && elm make --warn examples/simple/Simple.elm --output=examples/simple/simple.js
@@ -8,3 +8,6 @@ bootstrap-example:
 
 range-example:
 	cd .. && elm make --warn examples/range/Range.elm --output=examples/range/range.js
+
+simple-nightwatch-example:
+	cd .. && elm make --warn examples/simple-nightwatch/SimpleNightwatch.elm --output=examples/simple-nightwatch/simple-nightwatch.js

--- a/examples/simple-nightwatch/.gitignore
+++ b/examples/simple-nightwatch/.gitignore
@@ -1,0 +1,1 @@
+simple-nightwatch.js

--- a/examples/simple-nightwatch/SimpleNightwatch.elm
+++ b/examples/simple-nightwatch/SimpleNightwatch.elm
@@ -1,0 +1,92 @@
+module SimpleNightwatch exposing (main)
+
+{-| This is a simple test suitable for automated browser testing (such as with nightwatch.js)
+-}
+
+import Date exposing (Date, Day(..), day, dayOfWeek, month, year)
+import DatePicker exposing (defaultSettings, DateEvent(..))
+import Html exposing (Html, div, h1, text)
+
+
+type Msg
+    = ToDatePicker DatePicker.Msg
+
+
+type alias Model =
+    { date : Maybe Date
+    , datePicker : DatePicker.DatePicker
+    }
+
+
+settings : DatePicker.Settings
+settings =
+    defaultSettings
+
+
+init : ( Model, Cmd Msg )
+init =
+    let
+        moonLandingDate =
+            Date.fromString "1969-07-20"
+                |> Result.toMaybe
+                |> Maybe.withDefault (Date.fromTime 0)
+
+        -- the fromTime 0 is just to keep the compiler happy - it will never be called
+    in
+        ( { date = Nothing
+          , datePicker = DatePicker.initFromDate moonLandingDate
+          }
+        , Cmd.none
+        )
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg ({ date, datePicker } as model) =
+    case msg of
+        ToDatePicker msg ->
+            let
+                ( newDatePicker, datePickerFx, dateEvent ) =
+                    DatePicker.update settings msg datePicker
+
+                newDate =
+                    case dateEvent of
+                        Changed newDate ->
+                            newDate
+
+                        _ ->
+                            date
+            in
+                { model
+                    | date = newDate
+                    , datePicker = newDatePicker
+                }
+                    ! [ Cmd.map ToDatePicker datePickerFx ]
+
+
+view : Model -> Html Msg
+view ({ date, datePicker } as model) =
+    div []
+        [ case date of
+            Nothing ->
+                h1 [] [ text "Pick a date" ]
+
+            Just date ->
+                h1 [] [ text <| formatDate date ]
+        , DatePicker.view date settings datePicker
+            |> Html.map ToDatePicker
+        ]
+
+
+formatDate : Date -> String
+formatDate d =
+    toString (month d) ++ " " ++ toString (day d) ++ ", " ++ toString (year d)
+
+
+main : Program Never Model Msg
+main =
+    Html.program
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = always Sub.none
+        }

--- a/examples/simple-nightwatch/index.html
+++ b/examples/simple-nightwatch/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <title>elm-datepicker example</title>
+
+    <link rel="stylesheet"
+          type="text/css"
+          href="https://necolas.github.io/normalize.css/4.1.1/normalize.css" />
+
+    <link rel="stylesheet"
+          type="text/css"
+          href="https://fonts.googleapis.com/css?family=Roboto" />
+
+    <link rel="stylesheet"
+          type="text/css"
+          href="../../css/elm-datepicker.css" />
+
+    <style type="text/css">
+      body {
+          font-family: 'Roboto', sans-serif;
+      }
+
+      .container {
+          width: 680px;
+          margin: 0 auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div id="simple-nightwatch">
+      </div>
+    </div>
+
+    <script src="simple-nightwatch.js"></script>
+    <script>
+      Elm.SimpleNightwatch.embed(document.getElementById("simple-nightwatch"));
+    </script>
+  </body>
+</html>

--- a/nightwatch-tests/simple.js
+++ b/nightwatch-tests/simple.js
@@ -1,0 +1,41 @@
+const url = "http://localhost:8000/examples/simple-nightwatch/index.html";
+const textInputSelector = ".elm-datepicker--input";
+const topLeftDaySelector = ".elm-datepicker--row:first-child .elm-datepicker--day:first-child";
+
+module.exports = {
+
+  'When selecting a date with the mouse, it should appear in the text input' : function (client) {
+    client.url(url);
+    client.expect.element(textInputSelector).to.be.present.before(1000);
+    client.click(textInputSelector);
+    client.expect.element(topLeftDaySelector).to.be.present.before(1000);
+    client.click(topLeftDaySelector);
+    client.expect.element(textInputSelector).value.to.equal("1969/06/29").before(1000);
+    client.end();
+  },
+
+  'When entering text, and then selecting a date with the mouse, the selected date should appear in the text input' : function (client) {
+    client.url(url);
+    client.expect.element(textInputSelector).to.be.present.before(1000);
+    client.setValue(textInputSelector, "1 Jan 1980");
+    client.expect.element(topLeftDaySelector).to.be.present.before(1000);
+    client.click(topLeftDaySelector);
+    client.expect.element(textInputSelector).value.to.equal("1969/06/29").before(1000);
+    client.end();
+  },
+
+
+  // This test is disabled using !function. Remove to "!" to run it.
+  'Characters should not be dropped when entering text quickly' : !function (client) {
+
+    const longTextExample = "The quick brown fox jumped over the lazy dog";
+
+    client.url(url);
+    client.expect.element(textInputSelector).to.be.present.before(1000);
+    client.setValue(textInputSelector, longTextExample);
+    client.expect.element(topLeftDaySelector).to.be.present.before(1000);
+    client.expect.element(textInputSelector).value.to.equal(longTextExample);
+    client.end();
+  },
+
+};

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -1,0 +1,50 @@
+{
+  "src_folders" : ["nightwatch-tests"],
+  "output_folder" : "reports",
+  "custom_commands_path" : "",
+  "custom_assertions_path" : "",
+  "page_objects_path" : "",
+  "globals_path" : "",
+
+  "selenium" : {
+    "start_process" : false,
+    "server_path" : "",
+    "log_path" : "",
+    "port" : 4444,
+    "cli_args" : {
+      "webdriver.chrome.driver" : "",
+      "webdriver.gecko.driver" : "",
+      "webdriver.edge.driver" : ""
+    }
+  },
+
+  "test_settings" : {
+    "default" : {
+      "launch_url" : "http://localhost",
+      "selenium_port"  : 9515,
+      "selenium_host"  : "localhost",
+      "default_path_prefix" : "",
+      "silent": true,
+      "screenshots" : {
+        "enabled" : false,
+        "path" : ""
+      },
+      "desiredCapabilities": {
+        "browserName": "firefox",
+        "marionette": true
+      }
+    },
+
+    "chrome" : {
+      "desiredCapabilities": {
+        "browserName": "chrome"
+      }
+    },
+
+    "edge" : {
+      "desiredCapabilities": {
+        "browserName": "MicrosoftEdge"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "elm-datepicker",
+  "version": "1.0.0",
+  "description": "``` shell elm package install elm-community/elm-datepicker ```",
+  "main": "index.js",
+  "directories": {},
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elm-community/elm-datepicker.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/elm-community/elm-datepicker/issues"
+  },
+  "homepage": "https://github.com/elm-community/elm-datepicker#readme",
+  "devDependencies": {
+    "nightwatch": "^0.9.16"
+  }
+}

--- a/run-acceptance-tests
+++ b/run-acceptance-tests
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+
+# make sure latest build is being run
+
+cd examples && make simple-nightwatch-example && cd ..
+
+
+# start some required background processes
+
+elm-reactor &
+ELM_REACTOR_PID=$!
+
+chromedriver &
+CHROMEDRIVER_PID=$!
+
+
+# run nightwatch in the foreground
+
+./node_modules/.bin/nightwatch
+
+
+# after nightwatch exits, kill background processes
+
+echo "shutting down Elm Reactor with pkill elm-reactor"
+pkill elm-reactor
+echo "shutting down Chromedriver with PID $CHROMEDRIVER_PID"
+kill "$CHROMEDRIVER_PID"

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -38,7 +38,7 @@ module DatePicker
 import Date exposing (Date, Day(..), Month, day, month, year)
 import DatePicker.Date exposing (..)
 import Html exposing (..)
-import Html.Attributes as Attrs exposing (href, placeholder, tabindex, type_, value, defaultValue, selected)
+import Html.Attributes as Attrs exposing (href, placeholder, tabindex, type_, value, selected)
 import Html.Events exposing (on, onBlur, onClick, onInput, onFocus, onWithOptions, targetValue)
 import Html.Keyed
 import Json.Decode as Json
@@ -449,16 +449,15 @@ view pickedDate settings (DatePicker ({ open } as model)) =
                         (Maybe.map settings.dateFormatter pickedDate
                             |> Maybe.withDefault ""
                         )
-                    |> defaultValue
+                    |> value
                 ]
     in
-        Html.Keyed.node "div"
-            [ class "container" ]
-            [ ( "dateInput", dateInput )
+        div [ class "container" ]
+            [ dateInput
             , if open then
-                ( "datePicker", datePicker pickedDate settings model )
+                datePicker pickedDate settings model
               else
-                ( "text", text "" )
+                text ""
             ]
 
 


### PR DESCRIPTION
This PR does the following:

- Reverts PR #58 
- Adds Nightwatch acceptance tests for the following cases:
  - simple workflow of picking a date with the mouse
  - A  test case for https://github.com/elm-community/elm-datepicker/issues/62
  - A disabled (breaks when enabled) test case for https://github.com/elm-community/elm-datepicker/issues/63
- Adds an example in examples/simple-nightwatch that is used by the nightwatch tests
- Adds to the Readme instructions for running the nightwatch tests locally