### PR TITLE
Update link to simple example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ update msg model =
 See the [examples][examples] folder or try it on ellie-app: [simple] example and [bootstrap] example.
 
 [examples]: https://github.com/elm-community/elm-datepicker/tree/master/examples
-[simple]: https://ellie-app.com/pwFvvCqBgYa1/0
+[simple]: https://ellie-app.com/5QFsDgQVva1/0
 [bootstrap]: https://ellie-app.com/pwGJj5T6TBa1/0
 
 


### PR DESCRIPTION
The current Ellie example for a simple datepicker is using `date-picker` 3.0.0. I refactored that Ellie example to use 7.2.3, here is the link to the updated version.